### PR TITLE
出力ログの整理

### DIFF
--- a/include/obstacle_cloud_to_scan/obstacle_cloud_to_scan.hpp
+++ b/include/obstacle_cloud_to_scan/obstacle_cloud_to_scan.hpp
@@ -14,6 +14,9 @@
 #include <mutex>
 #include <rclcpp/time.hpp>
 #include <rclcpp/timer.hpp>
+#include <memory> // For std::shared_ptr
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 
 class ObstacleCloudToScanNode : public rclcpp::Node
 {
@@ -57,6 +60,12 @@ private:
     rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr filtered_cloud_publisher_;
     rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr scan_publisher_;
 
+    // TF2 members
+    std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+    std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+
+    // Parameters
+    std::string target_frame_; // Added this as it was missing but used in cpp
     std::string input_topic_;
     std::string output_topic_;
     std::string laser_scan_topic_;

--- a/include/obstacle_cloud_to_scan/obstacle_cloud_to_scan.hpp
+++ b/include/obstacle_cloud_to_scan/obstacle_cloud_to_scan.hpp
@@ -10,6 +10,10 @@
 #include <pcl/filters/passthrough.h>
 #include <pcl/features/normal_3d.h>
 #include <pcl_conversions/pcl_conversions.h>
+#include <vector>
+#include <mutex>
+#include <rclcpp/time.hpp>
+#include <rclcpp/timer.hpp>
 
 class ObstacleCloudToScanNode : public rclcpp::Node
 {
@@ -24,6 +28,7 @@ private:
  //   pcl::PointCloud<pcl::Normal>::Ptr estimateNormals(const pcl::PointCloud<pcl::PointXYZ>::Ptr &cloud);
   //  pcl::PointCloud<pcl::PointXYZ>::Ptr filterObstacles(const pcl::PointCloud<pcl::PointXYZ>::Ptr &cloud, const pcl::PointCloud<pcl::Normal>::Ptr &normals);
     void publishLaserScan(const pcl::PointCloud<pcl::PointXYZ>::Ptr &points, const std_msgs::msg::Header &header);
+    void logPerformance();
   
   /*  
     pcl::PointCloud<pcl::PointXYZ>::Ptr downsamplePointCloud(
@@ -66,6 +71,12 @@ private:
     double scan_angle_max_;
     double scan_range_min_;
     double scan_range_max_;
+
+    std::vector<double> processing_times_;
+    std::vector<size_t> downsampled_points_counts_;
+    rclcpp::Time last_log_time_;
+    rclcpp::TimerBase::SharedPtr logging_timer_;
+    std::mutex data_mutex_;
 };
 
 #endif // OBSTACLE_CLOUD_TO_SCAN_NODE_HPP

--- a/include/obstacle_cloud_to_scan/pcl_functions.hpp
+++ b/include/obstacle_cloud_to_scan/pcl_functions.hpp
@@ -9,8 +9,6 @@
 #include <pcl/features/normal_3d.h>
 #include <rclcpp/rclcpp.hpp>
 
-#include <chrono>
-
 // ダウンサンプリング
 pcl::PointCloud<pcl::PointXYZ>::Ptr downsamplePointCloud(
     const pcl::PointCloud<pcl::PointXYZ>::Ptr &cloud,

--- a/src/obstacle_cloud_to_scan.cpp
+++ b/src/obstacle_cloud_to_scan.cpp
@@ -257,3 +257,10 @@ void ObstacleCloudToScanNode::logPerformance()
     last_log_time_ = this->get_clock()->now(); // Update last log time
 }
 
+int main(int argc, char **argv)
+{
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<ObstacleCloudToScanNode>());
+    rclcpp::shutdown();
+    return 0;
+}

--- a/src/obstacle_cloud_to_scan.cpp
+++ b/src/obstacle_cloud_to_scan.cpp
@@ -14,12 +14,22 @@
 #include <pcl/common/transforms.h>
 #include <tf2_eigen/tf2_eigen.hpp>
 
-class ObstacleCloudToScanNode : public rclcpp::Node
-{
-public:
-    ObstacleCloudToScanNode() : Node("obstacle_cloud_to_scan")
+#include <chrono>
+#include <numeric>
+#include <functional>
+#include "obstacle_cloud_to_scan/obstacle_cloud_to_scan.hpp" // Make sure this is included
+
+// class ObstacleCloudToScanNode : public rclcpp::Node // This class is now defined in the .hpp
+// { // public: // All member function definitions should be outside if the class is in .hpp
+
+    ObstacleCloudToScanNode::ObstacleCloudToScanNode() : Node("obstacle_cloud_to_scan")
     {
         RCLCPP_DEBUG(this->get_logger(), "Initializing ObstacleCloudToScanNode");
+
+        last_log_time_ = this->get_clock()->now();
+        logging_timer_ = this->create_wall_timer(
+            std::chrono::seconds(1),
+            std::bind(&ObstacleCloudToScanNode::logPerformance, this));
 
         tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
         tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
@@ -40,24 +50,31 @@ public:
         RCLCPP_DEBUG(this->get_logger(), "Publisher created for topic: %s", output_topic_.c_str());
     }
 
-private:
+// private: // Member variables are now in the .hpp file
 
-    rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr point_cloud_subscriber_;
-    rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr filtered_cloud_publisher_;
+    // rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr point_cloud_subscriber_;
+    // rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr filtered_cloud_publisher_;
 
-    std::string target_frame_;
-    std::string input_topic_;
-    std::string output_topic_;
-    double voxel_leaf_size_;
-    std::vector<double> robot_box_size_;
-    std::vector<double> robot_box_position_;
-    double max_slope_angle_;
-    bool use_gpu_;
+    // std::string target_frame_;
+    // std::string input_topic_;
+    // std::string output_topic_;
+    // double voxel_leaf_size_;
+    // std::vector<double> robot_box_size_;
+    // std::vector<double> robot_box_position_;
+    // double max_slope_angle_;
+    // bool use_gpu_;
 
-    std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-    std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+    // std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+    // std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
+    // Member variables related to logging are in the hpp
+    // std::vector<double> processing_times_;
+    // std::vector<size_t> downsampled_points_counts_;
+    // rclcpp::Time last_log_time_;
+    // rclcpp::TimerBase::SharedPtr logging_timer_;
+    // std::mutex data_mutex_;
 
-    void declare_parameters()
+
+    void ObstacleCloudToScanNode::declare_parameters()
     {
         this->declare_parameter<std::string>("target_frame", "base_link");
         this->declare_parameter<std::string>("input_topic", "/input_cloud");
@@ -92,9 +109,9 @@ private:
         RCLCPP_INFO(this->get_logger(), "use_gpu: %s", use_gpu_ ? "true" : "false");
     }
 
-    void pointCloudCallback(const sensor_msgs::msg::PointCloud2::SharedPtr msg)
+    void ObstacleCloudToScanNode::pointCloudCallback(const sensor_msgs::msg::PointCloud2::SharedPtr msg)
     {
-        auto callback_start_time = std::chrono::high_resolution_clock::now(); // 計測開始
+        auto callback_start_time = std::chrono::high_resolution_clock::now();
         RCLCPP_DEBUG(this->get_logger(), "Received point cloud message");
 
         // 指定のTFフレームに転写
@@ -144,9 +161,9 @@ private:
         */
 
         auto tf_transforme_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-        std::chrono::duration<double, std::milli> tf_transforme_elapsed 
-                        = tf_transforme_end_time - callback_start_time;
-        RCLCPP_INFO(this->get_logger(), "tf fransforme took %.2f ms", tf_transforme_elapsed.count());
+        // std::chrono::duration<double, std::milli> tf_transforme_elapsed
+        //                 = tf_transforme_end_time - callback_start_time;
+        // RCLCPP_INFO(this->get_logger(), "tf fransforme took %.2f ms", tf_transforme_elapsed.count());
 
 /*
         pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
@@ -163,12 +180,13 @@ private:
         RCLCPP_DEBUG(this->get_logger(), "Starting downsampling");
         pcl::PointCloud<pcl::PointXYZ>::Ptr downsampled_cloud 
             = downsamplePointCloud(transformed_cloud, voxel_leaf_size_, use_gpu_, this->get_logger());
+        size_t num_downsampled_points = downsampled_cloud->points.size(); // Added
         RCLCPP_DEBUG(this->get_logger(), "Downsampling completed");
 
-        auto downsampling_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-        std::chrono::duration<double, std::milli> downsampling_elapsed 
-                        = downsampling_end_time - callback_start_time;
-        RCLCPP_INFO(this->get_logger(), "downsampling took %.2f ms", downsampling_elapsed.count());
+        // auto downsampling_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
+        // std::chrono::duration<double, std::milli> downsampling_elapsed
+        //                 = downsampling_end_time - callback_start_time;
+        // RCLCPP_INFO(this->get_logger(), "downsampling took %.2f ms", downsampling_elapsed.count());
 
         // パススルーフィルタの適用
         RCLCPP_DEBUG(this->get_logger(), "Starting passthrough filter");
@@ -176,10 +194,10 @@ private:
             = applyPassThroughFilter(downsampled_cloud, robot_box_size_, this->get_logger());
         RCLCPP_DEBUG(this->get_logger(), "Passthrough filter completed");
         
-        auto passthrough_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-        std::chrono::duration<double, std::milli> passthrough_elapsed 
-                        = passthrough_end_time - callback_start_time;
-        RCLCPP_INFO(this->get_logger(), "passthrough took %.2f ms", passthrough_elapsed.count());
+        // auto passthrough_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
+        // std::chrono::duration<double, std::milli> passthrough_elapsed
+        //                 = passthrough_end_time - callback_start_time;
+        // RCLCPP_INFO(this->get_logger(), "passthrough took %.2f ms", passthrough_elapsed.count());
 
 
         // ロボットの体の除去
@@ -188,20 +206,20 @@ private:
             = removeRobotBody(passthrough_cloud, robot_box_position_, robot_box_size_, this->get_logger());
         RCLCPP_DEBUG(this->get_logger(), "Robot body removal completed");
 
-        auto removeRobotBody_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-        std::chrono::duration<double, std::milli> removeRobotBody_elapsed 
-                        = removeRobotBody_end_time - callback_start_time;
-        RCLCPP_INFO(this->get_logger(), "removeRobotBody took %.2f ms", removeRobotBody_elapsed.count());
+        // auto removeRobotBody_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
+        // std::chrono::duration<double, std::milli> removeRobotBody_elapsed
+        //                 = removeRobotBody_end_time - callback_start_time;
+        // RCLCPP_INFO(this->get_logger(), "removeRobotBody took %.2f ms", removeRobotBody_elapsed.count());
 
         // 法線推定と傾斜の判定
         RCLCPP_DEBUG(this->get_logger(), "Starting normal estimation");
         pcl::PointCloud<pcl::Normal>::Ptr normals = estimateNormals(body_removed_cloud, this->get_logger());
         RCLCPP_DEBUG(this->get_logger(), "Normal estimation completed");
 
-        auto normals_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-        std::chrono::duration<double, std::milli> normals_elapsed 
-                        = normals_end_time - callback_start_time;
-        RCLCPP_INFO(this->get_logger(), "normals took %.2f ms", normals_elapsed.count());
+        // auto normals_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
+        // std::chrono::duration<double, std::milli> normals_elapsed
+        //                 = normals_end_time - callback_start_time;
+        // RCLCPP_INFO(this->get_logger(), "normals took %.2f ms", normals_elapsed.count());
 
         // 法線から不要な点群を除去
         RCLCPP_DEBUG(this->get_logger(), "Starting obstacle filtering");
@@ -209,10 +227,10 @@ private:
             = filterObstacles(body_removed_cloud, normals, max_slope_angle_, this->get_logger());
         RCLCPP_DEBUG(this->get_logger(), "Obstacle filtering completed");
 
-        auto filterObstacles_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-        std::chrono::duration<double, std::milli> filterObstacles_elapsed 
-                        = filterObstacles_end_time - callback_start_time;
-        RCLCPP_INFO(this->get_logger(), "filterObstacles took %.2f ms", filterObstacles_elapsed.count());
+        // auto filterObstacles_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
+        // std::chrono::duration<double, std::milli> filterObstacles_elapsed
+        //                 = filterObstacles_end_time - callback_start_time;
+        // RCLCPP_INFO(this->get_logger(), "filterObstacles took %.2f ms", filterObstacles_elapsed.count());
 
 
         // フィルタリング後の点群をパブリッシュ
@@ -220,22 +238,50 @@ private:
         sensor_msgs::msg::PointCloud2 filtered_msg;
         pcl::toROSMsg(*filtered_cloud, filtered_msg);
 
-        filtered_msg.header.frame_id = "base_link";
+        filtered_msg.header.frame_id = "base_link"; // Should be target_frame_
         filtered_msg.header.stamp = this->get_clock()->now();
         filtered_cloud_publisher_->publish(filtered_msg);
         
-        auto callback_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-        std::chrono::duration<double, std::milli> callback_elapsed 
-                        = callback_end_time - callback_start_time;
-        RCLCPP_INFO(this->get_logger(), "publish took %.2f ms", callback_elapsed.count());
-    }
-};
+        auto callback_end_time = std::chrono::high_resolution_clock::now();
+        double total_processing_time_ms = std::chrono::duration<double, std::milli>(callback_end_time - callback_start_time).count();
 
-int main(int argc, char **argv)
+        { // Scope for lock guard
+            std::lock_guard<std::mutex> lock(data_mutex_);
+            processing_times_.push_back(total_processing_time_ms);
+            downsampled_points_counts_.push_back(num_downsampled_points);
+        }
+        // RCLCPP_INFO(this->get_logger(), "publish took %.2f ms", callback_elapsed.count()); // Removed
+        RCLCPP_DEBUG(this->get_logger(), "PointCloud callback finished processing."); // Added for clarity
+    }
+
+// }; // This closes the class definition if it were here. Now it's in .hpp
+
+void ObstacleCloudToScanNode::logPerformance()
 {
-    rclcpp::init(argc, argv);
-    rclcpp::spin(std::make_shared<ObstacleCloudToScanNode>());
-    rclcpp::shutdown();
-    return 0;
+    std::lock_guard<std::mutex> lock(data_mutex_);
+
+    if (processing_times_.empty() || downsampled_points_counts_.empty())
+    {
+        return; // Nothing to log
+    }
+
+    double sum_processing_time = 0.0;
+    for (double time : processing_times_) {
+        sum_processing_time += time;
+    }
+    double avg_processing_time = sum_processing_time / processing_times_.size();
+
+    size_t sum_points = 0;
+    for (size_t count : downsampled_points_counts_) {
+        sum_points += count;
+    }
+    double avg_downsampled_points = static_cast<double>(sum_points) / downsampled_points_counts_.size();
+
+    RCLCPP_INFO(this->get_logger(), "Avg Process Time (last 1s): %.3f ms", avg_processing_time);
+    RCLCPP_INFO(this->get_logger(), "Avg Downsampled Points (last 1s): %.0f", avg_downsampled_points);
+
+    processing_times_.clear();
+    downsampled_points_counts_.clear();
+    last_log_time_ = this->get_clock()->now(); // Update last log time
 }
 

--- a/src/obstacle_cloud_to_scan.cpp
+++ b/src/obstacle_cloud_to_scan.cpp
@@ -17,10 +17,8 @@
 #include <chrono>
 #include <numeric>
 #include <functional>
-#include "obstacle_cloud_to_scan/obstacle_cloud_to_scan.hpp" // Make sure this is included
+#include "obstacle_cloud_to_scan/obstacle_cloud_to_scan.hpp"
 
-// class ObstacleCloudToScanNode : public rclcpp::Node // This class is now defined in the .hpp
-// { // public: // All member function definitions should be outside if the class is in .hpp
 
     ObstacleCloudToScanNode::ObstacleCloudToScanNode() : Node("obstacle_cloud_to_scan")
     {
@@ -50,30 +48,6 @@
         RCLCPP_DEBUG(this->get_logger(), "Publisher created for topic: %s", output_topic_.c_str());
     }
 
-// private: // Member variables are now in the .hpp file
-
-    // rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr point_cloud_subscriber_;
-    // rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr filtered_cloud_publisher_;
-
-    // std::string target_frame_;
-    // std::string input_topic_;
-    // std::string output_topic_;
-    // double voxel_leaf_size_;
-    // std::vector<double> robot_box_size_;
-    // std::vector<double> robot_box_position_;
-    // double max_slope_angle_;
-    // bool use_gpu_;
-
-    // std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-    // std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
-    // Member variables related to logging are in the hpp
-    // std::vector<double> processing_times_;
-    // std::vector<size_t> downsampled_points_counts_;
-    // rclcpp::Time last_log_time_;
-    // rclcpp::TimerBase::SharedPtr logging_timer_;
-    // std::mutex data_mutex_;
-
-
     void ObstacleCloudToScanNode::declare_parameters()
     {
         this->declare_parameter<std::string>("target_frame", "base_link");
@@ -89,7 +63,7 @@
 
     }
 
-    void get_parameters()
+    void ObstacleCloudToScanNode::get_parameters()
     {
         this->get_parameter("target_frame", target_frame_);
         this->get_parameter("input_topic", input_topic_);
@@ -253,8 +227,6 @@
         // RCLCPP_INFO(this->get_logger(), "publish took %.2f ms", callback_elapsed.count()); // Removed
         RCLCPP_DEBUG(this->get_logger(), "PointCloud callback finished processing."); // Added for clarity
     }
-
-// }; // This closes the class definition if it were here. Now it's in .hpp
 
 void ObstacleCloudToScanNode::logPerformance()
 {

--- a/src/obstacle_cloud_to_scan.cpp
+++ b/src/obstacle_cloud_to_scan.cpp
@@ -39,12 +39,8 @@
             input_topic_, 10, std::bind(&ObstacleCloudToScanNode::pointCloudCallback, this, std::placeholders::_1));
         RCLCPP_DEBUG(this->get_logger(), "Subscribed to topic: %s", input_topic_.c_str());
 
-        // Best Effort QoS設定
-        //auto best_effort_qos = rclcpp::QoS(rclcpp::KeepLast(5)).best_effort();
         auto reliable_qos = rclcpp::QoS(rclcpp::KeepLast(5)).reliable();
         filtered_cloud_publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(output_topic_,rclcpp::QoS(rclcpp::KeepLast(10)));
-        //filtered_cloud_publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(output_topic_, reliable_qos);
-        //filtered_cloud_publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(output_topic_, best_effort_qos);
         RCLCPP_DEBUG(this->get_logger(), "Publisher created for topic: %s", output_topic_.c_str());
     }
 
@@ -88,9 +84,6 @@
         auto callback_start_time = std::chrono::high_resolution_clock::now();
         RCLCPP_DEBUG(this->get_logger(), "Received point cloud message");
 
-        // 指定のTFフレームに転写
-        //sensor_msgs::msg::PointCloud2 transformed_cloud;
-        // PCLでTransformした場合
         geometry_msgs::msg::TransformStamped transform_stamped;
         try
         {
@@ -102,77 +95,28 @@
             RCLCPP_WARN(this->get_logger(), "Could not transform point cloud: %s", ex.what());
             return;
         }
-        // トランスフォームをEigenに変換
         Eigen::Affine3d transform = tf2::transformToEigen(transform_stamped.transform);
 
-        // sensor_msgs::PointCloud2 を pcl::PointCloud に変換
         pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
         pcl::fromROSMsg(*msg, *cloud);
 
-        // PCLで点群を変換
         pcl::PointCloud<pcl::PointXYZ>::Ptr transformed_cloud(new pcl::PointCloud<pcl::PointXYZ>);
         pcl::transformPointCloud(*cloud, *transformed_cloud, transform);
 
-        // doTransformでした場合
-        /*
-        try
-        {
-            geometry_msgs::msg::TransformStamped transform_stamped 
-                = tf_buffer_->lookupTransform("base_link", msg->header.frame_id, tf2::TimePointZero);
-
-            auto tf_receive_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-            std::chrono::duration<double, std::milli> tf_receive_elapsed 
-                        = tf_receive_end_time - callback_start_time;
-            RCLCPP_INFO(this->get_logger(), "tf receive took %.2f ms", tf_receive_elapsed.count());
-
-            tf2::doTransform(*msg, transformed_cloud, transform_stamped);
-        }
-        catch (tf2::TransformException &ex)
-        {
-            RCLCPP_WARN(this->get_logger(), "Could not transform point cloud: %s", ex.what());
-            return;
-        }
-        */
-
         auto tf_transforme_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-        // std::chrono::duration<double, std::milli> tf_transforme_elapsed
-        //                 = tf_transforme_end_time - callback_start_time;
-        // RCLCPP_INFO(this->get_logger(), "tf fransforme took %.2f ms", tf_transforme_elapsed.count());
-
-/*
-        pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
-        pcl::fromROSMsg(transformed_cloud, *cloud);
-
-        if (cloud->points.empty())
-        {
-            RCLCPP_WARN(this->get_logger(), "Could not read point cloud data cloud size: %lu", cloud->points.size());
-            return;
-        }
-        */
-
+          
         // ダウンサンプリング処理
         RCLCPP_DEBUG(this->get_logger(), "Starting downsampling");
         pcl::PointCloud<pcl::PointXYZ>::Ptr downsampled_cloud 
             = downsamplePointCloud(transformed_cloud, voxel_leaf_size_, use_gpu_, this->get_logger());
-        size_t num_downsampled_points = downsampled_cloud->points.size(); // Added
+        size_t num_downsampled_points = downsampled_cloud->points.size();
         RCLCPP_DEBUG(this->get_logger(), "Downsampling completed");
-
-        // auto downsampling_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-        // std::chrono::duration<double, std::milli> downsampling_elapsed
-        //                 = downsampling_end_time - callback_start_time;
-        // RCLCPP_INFO(this->get_logger(), "downsampling took %.2f ms", downsampling_elapsed.count());
 
         // パススルーフィルタの適用
         RCLCPP_DEBUG(this->get_logger(), "Starting passthrough filter");
         pcl::PointCloud<pcl::PointXYZ>::Ptr passthrough_cloud 
             = applyPassThroughFilter(downsampled_cloud, robot_box_size_, this->get_logger());
         RCLCPP_DEBUG(this->get_logger(), "Passthrough filter completed");
-        
-        // auto passthrough_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-        // std::chrono::duration<double, std::milli> passthrough_elapsed
-        //                 = passthrough_end_time - callback_start_time;
-        // RCLCPP_INFO(this->get_logger(), "passthrough took %.2f ms", passthrough_elapsed.count());
-
 
         // ロボットの体の除去
         RCLCPP_DEBUG(this->get_logger(), "Removing robot body from point cloud");
@@ -180,32 +124,16 @@
             = removeRobotBody(passthrough_cloud, robot_box_position_, robot_box_size_, this->get_logger());
         RCLCPP_DEBUG(this->get_logger(), "Robot body removal completed");
 
-        // auto removeRobotBody_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-        // std::chrono::duration<double, std::milli> removeRobotBody_elapsed
-        //                 = removeRobotBody_end_time - callback_start_time;
-        // RCLCPP_INFO(this->get_logger(), "removeRobotBody took %.2f ms", removeRobotBody_elapsed.count());
-
         // 法線推定と傾斜の判定
         RCLCPP_DEBUG(this->get_logger(), "Starting normal estimation");
         pcl::PointCloud<pcl::Normal>::Ptr normals = estimateNormals(body_removed_cloud, this->get_logger());
         RCLCPP_DEBUG(this->get_logger(), "Normal estimation completed");
-
-        // auto normals_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-        // std::chrono::duration<double, std::milli> normals_elapsed
-        //                 = normals_end_time - callback_start_time;
-        // RCLCPP_INFO(this->get_logger(), "normals took %.2f ms", normals_elapsed.count());
 
         // 法線から不要な点群を除去
         RCLCPP_DEBUG(this->get_logger(), "Starting obstacle filtering");
         pcl::PointCloud<pcl::PointXYZ>::Ptr filtered_cloud 
             = filterObstacles(body_removed_cloud, normals, max_slope_angle_, this->get_logger());
         RCLCPP_DEBUG(this->get_logger(), "Obstacle filtering completed");
-
-        // auto filterObstacles_end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-        // std::chrono::duration<double, std::milli> filterObstacles_elapsed
-        //                 = filterObstacles_end_time - callback_start_time;
-        // RCLCPP_INFO(this->get_logger(), "filterObstacles took %.2f ms", filterObstacles_elapsed.count());
-
 
         // フィルタリング後の点群をパブリッシュ
         RCLCPP_DEBUG(this->get_logger(), "Publishing filtered point cloud");
@@ -224,8 +152,7 @@
             processing_times_.push_back(total_processing_time_ms);
             downsampled_points_counts_.push_back(num_downsampled_points);
         }
-        // RCLCPP_INFO(this->get_logger(), "publish took %.2f ms", callback_elapsed.count()); // Removed
-        RCLCPP_DEBUG(this->get_logger(), "PointCloud callback finished processing."); // Added for clarity
+        RCLCPP_DEBUG(this->get_logger(), "PointCloud callback finished processing.");
     }
 
 void ObstacleCloudToScanNode::logPerformance()
@@ -254,7 +181,7 @@ void ObstacleCloudToScanNode::logPerformance()
 
     processing_times_.clear();
     downsampled_points_counts_.clear();
-    last_log_time_ = this->get_clock()->now(); // Update last log time
+    last_log_time_ = this->get_clock()->now();
 }
 
 int main(int argc, char **argv)

--- a/src/pcl_functions.cpp
+++ b/src/pcl_functions.cpp
@@ -6,7 +6,6 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr downsamplePointCloud(
     bool use_gpu,
     rclcpp::Logger logger)
 {
-    auto start_time = std::chrono::high_resolution_clock::now(); // 計測開始
     pcl::PointCloud<pcl::PointXYZ>::Ptr downsampled_cloud(new pcl::PointCloud<pcl::PointXYZ>);
     pcl::VoxelGrid<pcl::PointXYZ> voxel_filter;
     voxel_filter.setInputCloud(cloud);
@@ -23,10 +22,6 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr downsamplePointCloud(
         voxel_filter.filter(*downsampled_cloud);
     }
 
-    auto end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-    std::chrono::duration<double, std::milli> elapsed = end_time - start_time;
-    //RCLCPP_INFO(logger, "downsamplePointCloud took %.2f ms", elapsed.count());
-
     return downsampled_cloud;
 }
 
@@ -35,8 +30,6 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr applyPassThroughFilter(
     const std::vector<double> &robot_box_size,
     rclcpp::Logger logger)
 {
-    auto start_time = std::chrono::high_resolution_clock::now(); // 計測開始
-
     pcl::PointCloud<pcl::PointXYZ>::Ptr filtered_cloud(new pcl::PointCloud<pcl::PointXYZ>);
     pcl::PassThrough<pcl::PointXYZ> pass;
     pass.setInputCloud(cloud);
@@ -45,10 +38,6 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr applyPassThroughFilter(
     pass.filter(*filtered_cloud);
     RCLCPP_DEBUG(logger, "Passthrough filter applied");
 
-    auto end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-    std::chrono::duration<double, std::milli> elapsed = end_time - start_time;
-    //RCLCPP_INFO(logger, "applyPassThroughFilter took %.2f ms", elapsed.count());
-
     return filtered_cloud;
 }
 
@@ -56,8 +45,6 @@ pcl::PointCloud<pcl::Normal>::Ptr estimateNormals(
     const pcl::PointCloud<pcl::PointXYZ>::Ptr &cloud,
     rclcpp::Logger logger)
 {
-    auto start_time = std::chrono::high_resolution_clock::now(); // 計測開始
-
     pcl::PointCloud<pcl::Normal>::Ptr normals(new pcl::PointCloud<pcl::Normal>);
     pcl::NormalEstimation<pcl::PointXYZ, pcl::Normal> normal_estimation;
     normal_estimation.setInputCloud(cloud);
@@ -66,10 +53,6 @@ pcl::PointCloud<pcl::Normal>::Ptr estimateNormals(
     normal_estimation.setRadiusSearch(0.6);
     normal_estimation.compute(*normals);
     RCLCPP_DEBUG(logger, "Normal estimation completed");
-
-    auto end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-    std::chrono::duration<double, std::milli> elapsed = end_time - start_time;
-    //RCLCPP_INFO(logger, "estimateNormals took %.2f ms", elapsed.count());
 
     return normals;
 }
@@ -80,8 +63,6 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr filterObstacles(
     double max_slope_angle,
     rclcpp::Logger logger)
 {
-    auto start_time = std::chrono::high_resolution_clock::now(); // 計測開始
-
     RCLCPP_DEBUG(logger, "Normal cloud size: %ld", cloud->points.size());
     RCLCPP_DEBUG(logger, "Max angle slope: %f", max_slope_angle);
     pcl::PointCloud<pcl::PointXYZ>::Ptr filtered_cloud(new pcl::PointCloud<pcl::PointXYZ>);
@@ -100,10 +81,6 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr filterObstacles(
     }
     RCLCPP_DEBUG(logger, "Obstacle filtering completed");
 
-    auto end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-    std::chrono::duration<double, std::milli> elapsed = end_time - start_time;
-//    RCLCPP_INFO(logger, "filterObstacles took %.2f ms", elapsed.count());
-
     return filtered_cloud;
 }
 
@@ -113,8 +90,6 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr removeRobotBody(
     const std::vector<double> &box_size,
     rclcpp::Logger logger)
 {
-    auto start_time = std::chrono::high_resolution_clock::now(); // 計測開始
-
     pcl::CropBox<pcl::PointXYZ> crop_box_filter;
     crop_box_filter.setInputCloud(cloud);
 
@@ -136,10 +111,6 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr removeRobotBody(
     crop_box_filter.filter(*filtered_cloud);
 
     RCLCPP_DEBUG(logger, "Removed points within the robot body bounding box.");
-
-    auto end_time = std::chrono::high_resolution_clock::now(); // 計測終了
-    std::chrono::duration<double, std::milli> elapsed = end_time - start_time;
-    //RCLCPP_INFO(logger, "removeRobotBody took %.2f ms", elapsed.count());
 
     return filtered_cloud;
 }


### PR DESCRIPTION
処理ごとに意味のない経過時間を画面出力していたため、1秒ごとにシステム全体の経過時間を表示することにした。
ダウンサンプルした点数も追加